### PR TITLE
Remove unavailable item from `depends` field of library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Includes easy to follow examples for implementing velocity sensitive F
 category=Sensors
 url=https://github.com/joshnishikawa/MIDIcontroller
 architectures=avr
-depends=MIDI Library, Flicker, Bounce, Encoder
+depends=MIDI Library, Flicker, Encoder


### PR DESCRIPTION
The `depends` field of [the library.properties metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format) specifies the dependencies that should be installed along with
the library by the [Arduino Library Manager](https://docs.arduino.cc/software/ide-v1/tutorials/installing-libraries#using-the-library-manager).

This field must contain only the names of libraries that are available for installation via Library Manager.

The presence of any items which are not in Library Manager causes installation of the library to fail:

- [Arduino IDE 1.x](https://github.com/arduino/Arduino): "`no protocol:`" error
- [Arduino IDE 2.x](https://github.com/arduino/arduino-ide): fails silently ([`arduino/arduino-ide#621`](https://github.com/arduino/arduino-ide/issues/621))
- [Arduino CLI](https://arduino.github.io/arduino-cli/latest/): "`No valid dependencies solution found`" error

Fixes https://github.com/joshnishikawa/MIDIcontroller/issues/22
Fixes https://github.com/arduino/library-registry/issues/1895